### PR TITLE
Default archive range 1 day; fail-fast CLI with 3 retries and propagated errors

### DIFF
--- a/.github/_layouts/default.html
+++ b/.github/_layouts/default.html
@@ -107,9 +107,10 @@
         <div class="summary-controls-row">
           <label for="archive-range">过去</label>
           <select id="archive-range">
+            <option value="1" selected>1 天</option>
             <option value="7">7 天</option>
             <option value="14">14 天</option>
-            <option value="30" selected>30 天</option>
+            <option value="30">30 天</option>
             <option value="60">60 天</option>
             <option value="custom">自定义</option>
             <option value="all">全部</option>

--- a/src/arxiv_client.py
+++ b/src/arxiv_client.py
@@ -170,14 +170,14 @@ class ArxivClient:
                     all_results.append(metadata)
                     
                 except Exception as e:
-                    print(f"处理单篇文章时出错: {e}")
-                    continue
+                    raise RuntimeError(f"处理单篇文章时出错: {e}") from e
                 
         except Exception as e:
             print(f"搜索过程出错: {e}")
             print(f"错误类型: {type(e)}")
             import traceback
             print(f"错误堆栈: {traceback.format_exc()}")
+            raise
 
         if not all_results:
             print("未找到新的论文")

--- a/src/cli.py
+++ b/src/cli.py
@@ -26,43 +26,45 @@ def main():
     # 准备 last_run_file 路径
     last_run_file = os.path.join(args.output_dir, LAST_RUN_FILE)
     
-    # 获取论文
-    papers = arxiv_client.search_papers(
-        categories=args.categories, 
-        query=args.query,
-        last_run_file=last_run_file
-    )
-    if not papers:
-        print("未找到符合条件的论文")
-        return
-    
-    # 记录最新文章ID用于在摘要成功后保存
-    latest_entry_id = papers[0]['entry_id'] if papers else None
-    
-    # 生成摘要
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_file = os.path.join(args.output_dir, f"summary_{timestamp}.md")
-    
-    # 创建输出目录
-    os.makedirs(args.output_dir, exist_ok=True)
-    
-    # 生成摘要并保存
-    try:
-        success = paper_summarizer.summarize_papers(papers, output_file)
-        if success:
-            print(f"摘要已成功生成并保存到: {output_file}")
-        else:
-            print(f"摘要生成过程中出现错误，结果可能不完整: {output_file}")
-    except Exception as e:
-        print(f"生成摘要时发生错误: {e}")
-        success = False
-    
-    # 只有在摘要成功生成后才保存最新文章ID
-    if success and latest_entry_id and last_run_file:
-        arxiv_client.save_last_run_info(latest_entry_id, last_run_file, len(papers))
-        print(f"摘要成功生成，已更新运行记录。下次运行将从最新文章 ID 开始: {latest_entry_id}")
-    else:
-        print("由于摘要生成不完整或失败，未更新运行记录，下次运行将继续尝试获取这些论文。")
+    max_attempts = 3
+    for attempt in range(1, max_attempts + 1):
+        try:
+            print(f"开始第 {attempt} 次运行...")
+            papers = arxiv_client.search_papers(
+                categories=args.categories,
+                query=args.query,
+                last_run_file=last_run_file
+            )
+            if not papers:
+                print("未找到符合条件的论文")
+                return
+
+            # 记录最新文章ID用于在摘要成功后保存
+            latest_entry_id = papers[0]['entry_id'] if papers else None
+
+            # 生成摘要
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            output_file = os.path.join(args.output_dir, f"summary_{timestamp}.md")
+
+            # 生成摘要并保存
+            success = paper_summarizer.summarize_papers(papers, output_file)
+            if success:
+                print(f"摘要已成功生成并保存到: {output_file}")
+            else:
+                raise RuntimeError("摘要生成失败，停止此次运行。")
+
+            # 只有在摘要成功生成后才保存最新文章ID
+            if latest_entry_id and last_run_file:
+                arxiv_client.save_last_run_info(latest_entry_id, last_run_file, len(papers))
+                print(f"摘要成功生成，已更新运行记录。下次运行将从最新文章 ID 开始: {latest_entry_id}")
+            return
+        except Exception as e:
+            print(f"运行过程中发生错误: {e}")
+            if attempt < max_attempts:
+                print("准备重新从头开始运行...")
+                continue
+            print("已达到最大重试次数，退出且不更新任何内容。")
+            sys.exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
### Motivation
- Make the site default to showing only the latest day on load by defaulting the archive range to 1 day to match the requested UX change.  
- Prevent partial/incorrect state updates when failures occur by failing fast and avoiding writes to `last_run.json` or incomplete markdown files.  
- Surface upstream errors so retries can be attempted and transient failures recover without leaving partial output.

### Description
- Set the `archive-range` selector default option to `1` day in the site layout at `/.github/_layouts/default.html`.  
- Change `src/cli.py` to run the full workflow up to three times, returning on first success and calling `sys.exit(1)` only after exhausting retries, and only saving `last_run` info after a successful run.  
- Make `src/arxiv_client.py` propagate per-item processing errors by raising a `RuntimeError` (instead of swallowing and continuing) and re-raise search-level exceptions so the caller can retry or abort.  
- Update `src/paper_summarizer.py` to propagate LLM/API errors to callers instead of returning partial error fragments, ensure output directory creation with `Path(...).parent.mkdir(...)` before writing, and raise on failure so the CLI can handle retries and avoid partial writes.

### Testing
- Captured a visual verification screenshot of the updated layout by serving the repo locally and using Playwright to render `/.github/_layouts/default.html`, and the screenshot artifact was produced successfully.  
- Basic repository checks (file modifications and commit) completed successfully during the change.  
- Unit tests (`python -m unittest discover -s tests -v`) were not executed as part of this change and should be run in CI to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c3af008a48329b8bd0384188dc3c6)